### PR TITLE
Mesh

### DIFF
--- a/halo1/model.py
+++ b/halo1/model.py
@@ -170,7 +170,8 @@ def import_halo1_region(jms, *, scale=1.0):
 
 	mesh.normals_split_custom_set(tuple(itertools.chain(*tri_normals)))
 
-	# Blender won't display the normals if we don't set this for some reason.
+	# Blender will only display custom vertex normals with this enabled.
+	# 0.0 vectors are passed through to use actual auto smooth.
 
 	mesh.use_auto_smooth = True
 

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -46,7 +46,7 @@ def read_halo1model(filepath):
 
 		return jms
 
-def import_halo1_nodes(jms, *, scale=1.0, node_size=0.02):
+def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 	'''
 	Import all the nodes from a jms into the scene and returns a dict of them.
 	'''
@@ -66,7 +66,7 @@ def import_halo1_nodes(jms, *, scale=1.0, node_size=0.02):
 
 	return scene_nodes
 
-def import_halo1_markers(jms, *, scale=1.0, node_size=0.01,
+def import_halo1_markers_from_jms(jms, *, scale=1.0, node_size=0.01,
 		scene_nodes=dict(), import_radius=False,
 		permutation_filter=(), region_filter=()
 		):
@@ -117,7 +117,7 @@ def import_halo1_markers(jms, *, scale=1.0, node_size=0.01,
 
 	#TODO: Should this return something?
 
-def import_halo1_region(jms, *, scale=1.0, region_filter=()):
+def import_halo1_region_from_jms(jms, *, scale=1.0, region_filter=()):
 	'''
 	Imports all the geometry into a Halo 1 JMS into the scene.
 	'''

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -117,7 +117,7 @@ def import_halo1_markers_from_jms(jms, *, scale=1.0, node_size=0.01,
 
 	#TODO: Should this return something?
 
-def import_halo1_region_from_jms(jms, *, scale=1.0, region_filter=()):
+def import_halo1_region_from_jms(jms, *, name="", scale=1.0, region_filter=()):
 	'''
 	Imports all the geometry into a Halo 1 JMS into the scene.
 	'''
@@ -170,9 +170,6 @@ def import_halo1_region_from_jms(jms, *, scale=1.0, region_filter=()):
 
 	### Importing the data into a mesh
 
-	# Meshes and objects need names.
-	name = "placeholder name"
-
 	# Make a mesh to hold all relevant data.
 	mesh = bpy.data.meshes.new(name)
 
@@ -199,3 +196,17 @@ def import_halo1_region_from_jms(jms, *, scale=1.0, region_filter=()):
 	region_obj = bpy.data.objects.new(name, mesh)
 	scene = bpy.context.collection
 	scene.objects.link(region_obj)
+
+	return region_obj
+
+def import_halo1_all_regions_from_jms(jms, *, name="", scale=1.0):
+	'''
+	Import all regions from a given jms.
+	'''
+	for i in range(len(jms.regions)):
+		import_halo1_region_from_jms(
+			jms,
+			name=name+":"+jms.regions[i],
+			scale=scale,
+			region_filter=(i,)
+		)

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -152,9 +152,10 @@ def import_halo1_region(jms, *, scale=1.0):
 	# Get the edge normals for each triangle using the vertex indices.
 
 	tri_normals = map(
-		lambda t : (vertex_normals[t[0]],
-					vertex_normals[t[1]],
-					vertex_normals[t[2]]),
+		lambda t : (
+			vertex_normals[t[0]],
+			vertex_normals[t[1]],
+			vertex_normals[t[2]]),
 		triangles
 	)
 

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -8,7 +8,7 @@ from reclaimer.model.model_decompilation import extract_model
 
 from ..constants import ( JMS_VERSION_HALO_1, NODE_NAME_PREFIX, MARKER_NAME_PREFIX )
 from ..scene.shapes import create_sphere
-from ..scene.util import set_uniform_scale
+from ..scene.util import set_uniform_scale, reduce_vertices
 from ..scene.jms_util import ( set_rotation_from_jms,
 	set_translation_from_jms )
 
@@ -155,6 +155,9 @@ def import_halo1_region_from_jms(jms, *, scale=1.0, region_filter=()):
 			vertex_normals[t[2]]),
 		triangles
 	)
+
+	# Remove unused vertices
+	vertices, triangles = reduce_vertices(vertices, triangles)
 
 	# Chain all of the triangle normals together into loop normals.
 	# ((x, y, z), (x, y, z), (x, y, z)), ((x, y, z), (x, y, z), (x, y, z)),

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -180,8 +180,8 @@ def import_halo1_region_from_jms(jms, *, name="unnamed", scale=1.0, region_filte
 	# Import loop normals into the mesh.
 	mesh.normals_split_custom_set(loop_normals)
 
-	# Blender will only display custom vertex normals with this enabled.
-	# 0.0 vectors are passed through to use actual auto smooth.
+	# Setting this to true makes Blender display the custom normals.
+	# It feels really wrong. But it is right.
 	mesh.use_auto_smooth = True
 
 	# Validate the mesh and make sure it doesn't have any invalid indices.

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -175,24 +175,19 @@ def import_halo1_region_from_jms(jms, *, name="", scale=1.0, region_filter=()):
 
 	# Import the verts and tris into the mesh.
 	# verts, edges, tris. If () is given for edges Blender will infer them.
-
 	mesh.from_pydata(vertices, (), triangles)
 
 	# Import loop normals into the mesh.
-
 	mesh.normals_split_custom_set(loop_normals)
 
 	# Blender will only display custom vertex normals with this enabled.
 	# 0.0 vectors are passed through to use actual auto smooth.
-
 	mesh.use_auto_smooth = True
 
 	# Validate the mesh and make sure it doesn't have any invalid indices.
-
 	mesh.validate()
 
 	# Create the object, and link it to the scene.
-
 	region_obj = bpy.data.objects.new(name, mesh)
 	scene = bpy.context.collection
 	scene.objects.link(region_obj)

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -117,7 +117,7 @@ def import_halo1_markers_from_jms(jms, *, scale=1.0, node_size=0.01,
 
 	#TODO: Should this return something?
 
-def import_halo1_region_from_jms(jms, *, name="", scale=1.0, region_filter=()):
+def import_halo1_region_from_jms(jms, *, name="unnamed", scale=1.0, region_filter=()):
 	'''
 	Imports all the geometry into a Halo 1 JMS into the scene.
 	'''

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -122,7 +122,7 @@ def import_halo1_region_from_jms(jms, *, name="", scale=1.0, region_filter=()):
 	Imports all the geometry into a Halo 1 JMS into the scene.
 	'''
 
-	if not len(region_filter):
+	if not region_filter:
 		region_filter = range(len(jms.regions))
 
 	### Geometry preprocessing.

--- a/menu/import_export/halo1_model.py
+++ b/menu/import_export/halo1_model.py
@@ -4,7 +4,7 @@ from bpy.props import BoolProperty, FloatProperty, StringProperty, EnumProperty
 from bpy_extras.io_utils import ImportHelper, ExportHelper, orientation_helper, path_reference_mode, axis_conversion
 
 from ...halo1.model import ( read_halo1model, import_halo1_nodes,
-	import_halo1_markers )
+	import_halo1_markers, import_halo1_region )
 from ...constants import SCALE_MULTIPLIERS
 
 #@orientation_helper(axis_forward='-Z') Find the right value for this.
@@ -94,6 +94,8 @@ class MT_krieg_ImportHalo1Model(bpy.types.Operator, ImportHelper):
 		nodes = import_halo1_nodes(jms, scale=scale, node_size=self.node_size)
 		import_halo1_markers(jms, scale=scale,
 			node_size=self.marker_size, scene_nodes=nodes)
+
+		import_halo1_region(jms, scale=scale)
 
 		return {'FINISHED'}
 

--- a/menu/import_export/halo1_model.py
+++ b/menu/import_export/halo1_model.py
@@ -3,8 +3,12 @@ from bpy.utils import register_class, unregister_class
 from bpy.props import BoolProperty, FloatProperty, StringProperty, EnumProperty
 from bpy_extras.io_utils import ImportHelper, ExportHelper, orientation_helper, path_reference_mode, axis_conversion
 
-from ...halo1.model import ( read_halo1model, import_halo1_nodes,
-	import_halo1_markers, import_halo1_region )
+from ...halo1.model import (
+	read_halo1model,
+	import_halo1_nodes_from_jms,
+	import_halo1_markers_from_jms,
+	import_halo1_region_from_jms,
+)
 from ...constants import SCALE_MULTIPLIERS
 
 #@orientation_helper(axis_forward='-Z') Find the right value for this.
@@ -91,11 +95,11 @@ class MT_krieg_ImportHalo1Model(bpy.types.Operator, ImportHelper):
 		jms = read_halo1model(self.filepath)
 
 		# Import nodes into the scene.
-		nodes = import_halo1_nodes(jms, scale=scale, node_size=self.node_size)
-		import_halo1_markers(jms, scale=scale,
+		nodes = import_halo1_nodes_from_jms(jms, scale=scale, node_size=self.node_size)
+		import_halo1_markers_from_jms(jms, scale=scale,
 			node_size=self.marker_size, scene_nodes=nodes)
 
-		import_halo1_region(jms, scale=scale)
+		import_halo1_region_from_jms(jms, scale=scale, region_filter=(0,))
 
 		return {'FINISHED'}
 

--- a/menu/import_export/halo1_model.py
+++ b/menu/import_export/halo1_model.py
@@ -99,7 +99,7 @@ class MT_krieg_ImportHalo1Model(bpy.types.Operator, ImportHelper):
 		import_halo1_markers_from_jms(jms, scale=scale,
 			node_size=self.marker_size, scene_nodes=nodes)
 
-		import_halo1_region_from_jms(jms, scale=scale, region_filter=(0,))
+		import_halo1_region_from_jms(jms, scale=scale, region_filter=())
 
 		return {'FINISHED'}
 

--- a/menu/import_export/halo1_model.py
+++ b/menu/import_export/halo1_model.py
@@ -1,4 +1,5 @@
 import bpy
+import os
 from bpy.utils import register_class, unregister_class
 from bpy.props import BoolProperty, FloatProperty, StringProperty, EnumProperty
 from bpy_extras.io_utils import ImportHelper, ExportHelper, orientation_helper, path_reference_mode, axis_conversion
@@ -7,7 +8,7 @@ from ...halo1.model import (
 	read_halo1model,
 	import_halo1_nodes_from_jms,
 	import_halo1_markers_from_jms,
-	import_halo1_region_from_jms,
+	import_halo1_all_regions_from_jms,
 )
 from ...constants import SCALE_MULTIPLIERS
 
@@ -94,12 +95,15 @@ class MT_krieg_ImportHalo1Model(bpy.types.Operator, ImportHelper):
 		# Test if jms import function doesn't crash.
 		jms = read_halo1model(self.filepath)
 
+		# Get name without path or file extension.
+		name = os.path.basename(os.path.splitext(self.filepath)[0])
+
 		# Import nodes into the scene.
 		nodes = import_halo1_nodes_from_jms(jms, scale=scale, node_size=self.node_size)
 		import_halo1_markers_from_jms(jms, scale=scale,
 			node_size=self.marker_size, scene_nodes=nodes)
 
-		import_halo1_region_from_jms(jms, scale=scale, region_filter=())
+		import_halo1_all_regions_from_jms(jms, name=name, scale=scale)
 
 		return {'FINISHED'}
 

--- a/scene/util.py
+++ b/scene/util.py
@@ -58,36 +58,41 @@ def set_uniform_scale(scene_object, scale=1.0):
 
 def reduce_vertices(verts, tris):
 	'''
-	Takes a set of preprocessed vertices and triangles and deletes and unused
-	or double vertices.
+	Takes a set of preprocessed vertices and triangles and deletes unused
+	or duplicate vertices.
 	'''
 
-	### Remove unused vertices
-
 	# Get a set of all vertex indices used by the tris
-
 	used_indices = set(itertools.chain(*tris))
 
+	# Translation dict that contains the unique vertices as keys, and their new
+	# indices as values.
 	translation_dict = {}
+	# List of unique vertices.
 	unique_verts = []
 
 	for i in used_indices:
 		count = len(unique_verts)
-
 		vert = verts[i]
 
+		# Returns the id for an existing identical vertex if it exists.
+		# Returns the next index of the unique_verts list if not found.
 		new_id = translation_dict.setdefault(vert, count)
 
+		# If the new id is not within the list
+		# we need to add the vert to the end of our condensed list.
 		if not new_id < count:
 			unique_verts.append(vert)
 
-	new_tris = tuple(
-		map(lambda t : (
+	# Convert the vertex ids in the triangles to ids that properly reference
+	# the new list.
+	new_tris = map(
+		lambda t : (
 			translation_dict[verts[t[0]]],
 			translation_dict[verts[t[1]]],
 			translation_dict[verts[t[2]]],
-			), tris
-		)
+		), tris
 	)
 
-	return unique_verts, new_tris
+	# Return as tuples because they are nice and fast.
+	return tuple(unique_verts), tuple(new_tris)

--- a/scene/util.py
+++ b/scene/util.py
@@ -78,7 +78,7 @@ def reduce_vertices(verts, tris):
 		new_i = translation_dict.setdefault(old_i, next_i)
 
 		# This shouldn't be possible. But better to be paranoid than sorry.
-		assert new_i <= next_i, "Reached in invalid id."
+		assert new_i <= next_i, "Reached an invalid id."
 
 		# If the new index is actually new we append its corresponding vertex
 		# to our new vertex list.

--- a/scene/util.py
+++ b/scene/util.py
@@ -1,6 +1,7 @@
 '''
 Functions for interfacing Halo stuff with the Blender scene.
 '''
+import itertools
 
 def set_rotation(scene_object, *, i=0.0, j=0.0, k=0.0, w=-1.0):
 	'''
@@ -54,3 +55,39 @@ def get_translation(scene_object, scale=1.0):
 def set_uniform_scale(scene_object, scale=1.0):
 	'''Takes a blender object and sets all of its axis to the same scale.'''
 	scene_object.scale = (scale, scale, scale)
+
+def reduce_vertices(verts, tris):
+	'''
+	Takes a set of preprocessed vertices and triangles and deletes and unused
+	or double vertices.
+	'''
+
+	### Remove unused vertices
+
+	# Get a set of all vertex indices used by the tris
+
+	used_indices = set(itertools.chain(*tris))
+
+	translation_dict = {}
+	unique_verts = []
+
+	for i in used_indices:
+		count = len(unique_verts)
+
+		vert = verts[i]
+
+		new_id = translation_dict.setdefault(vert, count)
+
+		if not new_id < count:
+			unique_verts.append(vert)
+
+	new_tris = tuple(
+		map(lambda t : (
+			translation_dict[verts[t[0]]],
+			translation_dict[verts[t[1]]],
+			translation_dict[verts[t[2]]],
+			), tris
+		)
+	)
+
+	return unique_verts, new_tris


### PR DESCRIPTION
Implements mesh import with proper vertex normal support.

Renames halo1 model functions to be appended with _from_jms for whenever we start using a different intermediate format.

