### PR TITLE
Test mock rotation

### DIFF
--- a/test/mock/bpy.py
+++ b/test/mock/bpy.py
@@ -7,7 +7,7 @@
 # basic lists and dictionaries instead of whatever Blender is using.
 # This should, in theory, be a drop-in replacement for testing.
 
-from mathutils import Euler, Vector
+from mathutils import Euler, Quaternion, Vector
 
 class Data:
 	def __init__(self):
@@ -29,6 +29,7 @@ class Object:
 		self.parent = None             # The object this object is parented to
 		self.rotation_euler = Euler()  # Rotation in Euler coordinates
 		self.rotation_mode = 'XYZ'     # Rotation mode (or Euler coordinate order)
+		self.rotation_quaternion = Quaternion() # Rotation in Quaternion coordinates
 		self.users_collection = set()  # All the collections this object belongs to
 
 
@@ -58,12 +59,16 @@ def _add_objects(nested, parent=None, parent_colls=set()):
 
 		rot = nested[name].get('rotation', Euler())
 		if isinstance(rot, Euler):
-			obj.rotation_euler = rot
-
 			# FIXME This is hard-coded as XYZ for now because mathutils 2.81.2
 			# doesn't support other orders for Euler coordinates.
+			# TODO is this how Blender handles setting rotation for other modes?
 			obj.rotation_mode = 'XYZ'
-		# TODO Set Quaternion and handle Quaternion and mode
+			obj.rotation_euler = rot
+			obj.rotation_quaternion = rot.to_quaternion()
+		elif isinstance(rot, Quaternion):
+			obj.rotation_mode = 'QUATERNION'
+			obj.rotation_quaternion = rot
+			obj.rotation_euler = rot.to_euler()
 		else:
 			raise Exception('Invalid rotation type: ' + str(type(rot)))
 

--- a/test/mock/bpy.py
+++ b/test/mock/bpy.py
@@ -7,7 +7,7 @@
 # basic lists and dictionaries instead of whatever Blender is using.
 # This should, in theory, be a drop-in replacement for testing.
 
-from mathutils import Vector
+from mathutils import Euler, Vector
 
 class Data:
 	def __init__(self):
@@ -27,6 +27,8 @@ class Object:
 		self.location = Vector()       # Coordinate location of this object
 		self.name = None               # Name as it appears in Outliner
 		self.parent = None             # The object this object is parented to
+		self.rotation_euler = Euler()  # Rotation in Euler coordinates
+		self.rotation_mode = 'XYZ'     # Rotation mode (or Euler coordinate order)
 		self.users_collection = set()  # All the collections this object belongs to
 
 
@@ -53,6 +55,17 @@ def _add_objects(nested, parent=None, parent_colls=set()):
 
 		loc = nested[name].get('location', Vector())
 		obj.location = Vector((loc[0], loc[1], loc[2]))
+
+		rot = nested[name].get('rotation', Euler())
+		if isinstance(rot, Euler):
+			obj.rotation_euler = rot
+
+			# FIXME This is hard-coded as XYZ for now because mathutils 2.81.2
+			# doesn't support other orders for Euler coordinates.
+			obj.rotation_mode = 'XYZ'
+		# TODO Set Quaternion and handle Quaternion and mode
+		else:
+			raise Exception('Invalid rotation type: ' + str(type(rot)))
 
 		if parent:
 			obj.parent = parent

--- a/test/mock/mock_test.py
+++ b/test/mock/mock_test.py
@@ -1,6 +1,6 @@
 from pocha import *
 from hamcrest import *
-from mathutils import Euler, Vector
+from mathutils import Euler, Quaternion, Vector
 
 import bpy
 # Put this assert outside of the Pocha stuff so we exception out before we even
@@ -273,4 +273,59 @@ def blenderMockTests():
 	# setting the coordinate order for Euler rotation. When that support is
 	# added, we'll want to add another test here for changing rotation mode to
 	# 'ZYX' and making sure the coordinates are re-ordered.
+
+	@it('Getting object rotation (quaternion')
+	def objectRotationQuaternionGet():
+		bpy.set_scene_data({
+			'obj1': {},
+			'obj2': {
+				'rotation': Quaternion((1, 2, 3, 4))
+			}
+		})
+
+		obj1 = bpy.data.objects.get('obj1')
+		obj2 = bpy.data.objects.get('obj2')
+
+		assert_that(obj1.rotation_quaternion,
+			equal_to(Quaternion((1, 0, 0, 0))),
+			'Object rotation defaults to (1, 0, 0, 0)')
+
+		assert_that(obj1.rotation_mode,
+			equal_to('XYZ'),
+			'Rotation mode defaults to XYZ')
+
+		assert_that(obj2.rotation_mode,
+			equal_to('QUATERNION'),
+			'Rotation mode changes to QUATERNION for Quaternions')
+
+		rot = obj2.rotation_quaternion
+		assert_that(rot, equal_to(Quaternion((1, 2, 3, 4))), 'Object rotation is set')
+		assert_that(rot.w, equal_to(1), 'W component addressable')
+		assert_that(rot.x, equal_to(2), 'X component addressable')
+		assert_that(rot.y, equal_to(3), 'Y component addressable')
+		assert_that(rot.z, equal_to(4), 'Z component addressable')
+
+	@it('Setting object rotation (quaternion)')
+	def objectRotationQuaterionSet():
+		bpy.set_scene_data({
+			'obj1': {},
+			'obj2': {}
+		})
+
+		obj1 = bpy.data.objects.get('obj1')
+		obj2 = bpy.data.objects.get('obj2')
+
+		obj1.rotation_quaternion = Quaternion((1, 2, 3, 4))
+		obj2.rotation_quaternion.w = 1
+		obj2.rotation_quaternion.x = 2
+		obj2.rotation_quaternion.y = 3
+		obj2.rotation_quaternion.z = 4
+
+		assert_that(obj1.rotation_quaternion,
+			equal_to(Quaternion((1, 2, 3, 4))),
+			'Object rotation set by Quaternion')
+
+		assert_that(obj2.rotation_quaternion,
+			equal_to(Quaternion((1, 2, 3, 4))),
+			'Object rotation set by components')
 

--- a/test/mock/mock_test.py
+++ b/test/mock/mock_test.py
@@ -1,6 +1,6 @@
 from pocha import *
 from hamcrest import *
-from mathutils import Vector
+from mathutils import Euler, Vector
 
 import bpy
 # Put this assert outside of the Pocha stuff so we exception out before we even
@@ -219,4 +219,58 @@ def blenderMockTests():
 		assert_that(obj2.location,
 			equal_to(Vector((4, 5, 6))),
 			'Object location set by components')
+
+	@it('Getting object rotation (euler)')
+	def objectRotationEulerGet():
+		bpy.set_scene_data({
+			'obj1': {},
+			'obj2': {
+				'rotation': Euler((1, 2, 3))
+			}
+		})
+
+		obj1 = bpy.data.objects.get('obj1')
+		obj2 = bpy.data.objects.get('obj2')
+
+		assert_that(obj1.rotation_euler,
+			equal_to(Euler((0, 0, 0))),
+			'Object rotation defaults to (0, 0, 0)')
+
+		assert_that(obj1.rotation_mode,
+			equal_to('XYZ'),
+			'Object rotation defaults to XYZ')
+
+		rot = obj2.rotation_euler
+		assert_that(rot, equal_to(Euler((1, 2, 3))), 'Object rotation is set')
+		assert_that(rot.x, equal_to(1), 'X component addressable')
+		assert_that(rot.y, equal_to(2), 'Y component addressable')
+		assert_that(rot.z, equal_to(3), 'Z component addressable')
+
+	@it('Setting object rotation (euler)')
+	def objectRotationEulerSet():
+		bpy.set_scene_data({
+			'obj1': {},
+			'obj2': {}
+		})
+
+		obj1 = bpy.data.objects.get('obj1')
+		obj2 = bpy.data.objects.get('obj2')
+
+		obj1.rotation_euler = Euler((1, 2, 3))
+		obj2.rotation_euler.x = 1
+		obj2.rotation_euler.y = 2
+		obj2.rotation_euler.z = 3
+
+		assert_that(obj1.rotation_euler,
+			equal_to(Euler((1, 2, 3))),
+			'Object rotation set by Euler')
+
+		assert_that(obj2.rotation_euler,
+			equal_to(Euler((1, 2, 3))),
+			'Object rotation set by components')
+
+	# TODO the standalone mathutils we're using (v2.81.2) doesn't support
+	# setting the coordinate order for Euler rotation. When that support is
+	# added, we'll want to add another test here for changing rotation mode to
+	# 'ZYX' and making sure the coordinates are re-ordered.
 


### PR DESCRIPTION
Should handle #18.

Turns out this is a lot less complex that it seems. Blender only updates the rotation value that matches the current rotation mode, so if we're using mocks that aren't actually rotating things, that distinction doesn't matter.