### PR TITLE
Switch node import implementation from spheres to armatures

### DIFF
--- a/halo1/model.py
+++ b/halo1/model.py
@@ -101,7 +101,7 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 		thingy.rotate(rot)
 		scene_node.tail = scene_node.head + thingy
 
-		#scene_node.roll = Quaternion((-node.rot_w, node.rot_i, node.rot_j, node.rot_k)).to_euler('XYZ').y
+		scene_node.roll = Quaternion((-node.rot_w, node.rot_i, node.rot_j, node.rot_k)).to_euler('XYZ').z
 
 		parent_children[i] = scene_node
 		children[node.parent_index] = parent_children

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -103,6 +103,31 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02, extend_nodes=
 		# Store the info we gathered this cycle.
 		scene_nodes[i] = scene_node
 
+	# Collect all the bone prefixes that need to be attached in a tuple.
+
+	attach_bones = ()
+	for k in extend_nodes:
+		if extend_nodes[k]:
+			attach_bones += (k,)
+
+	# Attach all the bones that we should attach if we can safely do so.
+
+	for bone in armature.edit_bones:
+		children = bone.children
+
+		if len(children) == 1 # Can't connect to multiple children, so don't.
+		and bone.name[len(NODE_NAME_PREFIX): ].startswith(attach_bones):
+			# TODO: We need to check if the child node is on the same line as
+			# the parent. Otherwise this will break.
+
+			# If the child bone's head is on a line with the parent's tail
+			# direction we can set the parent tail to the location of the child
+			# head.
+			bone.tail = children[0].head
+			# Connect the bone so it stays attached when editing.
+			children[0].use_connect = True
+
+
 	bpy.ops.object.mode_set(mode='OBJECT')
 
 	return scene_nodes

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -57,7 +57,16 @@ def import_halo1_nodes_from_jms(jms, *,
 		max_attachment_distance=0.00001,
 		attach_bones=('bip01',)):
 	'''
-	Import all the nodes from a jms into the scene and returns a dict of them.
+	Import all the nodes from a jms into the scene as an armature and returns
+	a dict of them.
+
+	node_size are is currently unused and may be depricated.
+
+	max_attachment_distance is the max distance a bone may deviate from
+	the line that signifies the direction of the parent.
+
+	attach_bones is a tuple of prefixes that this function should attempt to
+	connect.
 	'''
 	view_layer = bpy.context.view_layer
 
@@ -122,12 +131,17 @@ def import_halo1_nodes_from_jms(jms, *,
 		direction.rotate(rot)
 		directions[scene_node.name] = direction
 
+	if len(attach_bones) > 0:
+		print('Checking if any bones with the prefixes %s can be connected.\n' %
+				(attach_bones,))
+
 	# Attach all the bones that we should attach if we can safely do so.
 	for bone in armature.edit_bones:
 		children = bone.children
 
 		if (len(children) == 1 # Can't connect to multiple children, so don't.
-		and bone.name[len(NODE_NAME_PREFIX): ].startswith(attach_bones)):
+		and bone.name[len(NODE_NAME_PREFIX): ].startswith(attach_bones)
+		and children[0].name[len(NODE_NAME_PREFIX): ].startswith(attach_bones)):
 			child_head = children[0].head
 
 			distance = point_distance_to_line(

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -95,23 +95,21 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02, extend_nodes=
 
 		# Then we add the absolute location to both the head and the tail.
 
-		base_pos = scene_node.head
-		scene_node.head = (base_pos.x + pos[0] * scale, base_pos.y + pos[1] * scale, base_pos.z + pos[2] * scale)
-		base_tail = scene_node.tail
-		scene_node.tail = (base_tail.x + pos[0] * scale, base_tail.y + pos[1] * scale, base_tail.z + pos[2] * scale)
+		scene_node.head += Vector(
+			(pos[0] * scale, pos[1] * scale, pos[2] * scale))
+		scene_node.tail += Vector(
+			(pos[0] * scale, pos[1] * scale, pos[2] * scale))
 
 		# Store the info we gathered this cycle.
 		scene_nodes[i] = scene_node
 
 	# Collect all the bone prefixes that need to be attached in a tuple.
-
 	attach_bones = ()
 	for k in extend_nodes:
 		if extend_nodes[k]:
 			attach_bones += (k,)
 
 	# Attach all the bones that we should attach if we can safely do so.
-
 	for bone in armature.edit_bones:
 		children = bone.children
 
@@ -127,6 +125,7 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02, extend_nodes=
 			# Connect the bone so it stays attached when editing.
 			children[0].use_connect = True
 
+	# Change back to object mode so the rest of the script can execute properly.
 
 	bpy.ops.object.mode_set(mode='OBJECT')
 

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -13,7 +13,7 @@ from reclaimer.util.geometry import point_distance_to_line
 from ..constants import (JMS_VERSION_HALO_1, NODE_NAME_PREFIX,
 	MARKER_NAME_PREFIX)
 from ..scene.shapes import create_sphere
-from ..scene.util import (set_uniform_scale, reduce_vertices)
+from ..scene.util import (set_uniform_scale, reduce_vertices, trace_into_direction)
 from ..scene.jms_util import (set_rotation_from_jms,
 	set_translation_from_jms, get_absolute_node_transforms_from_jms)
 
@@ -112,9 +112,10 @@ def import_halo1_nodes_from_jms(jms, *,
 		rot = absolute_transforms[i]['rotation']
 
 		# Bones when created start at 0 0 0 for their tail and head.
-		# We extend the tail so it sticks out a bit and signifies the direction.
+		# We set the X of the tail, so it's not 0 length.
+		# X also is the forward direction for Halo bones.
 
-		scene_node.tail = (scene_node.bbone_x, 0.0, 0.0)
+		scene_node.tail.x = 0.2
 
 		# We then rotate the bone by the absolute rotation that it should have.
 
@@ -131,10 +132,7 @@ def import_halo1_nodes_from_jms(jms, *,
 		scene_nodes[i] = scene_node
 
 		# Store a "direction" for this node
-
-		direction = Vector((1000.0, 0.0, 0.0))
-		direction.rotate(rot)
-		directions[scene_node.name] = direction
+		directions[scene_node.name] = trace_into_direction(rot)
 
 	if len(attach_bones) > 0:
 		print('Checking if any bones with the prefixes %s can be connected.\n' %

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -85,7 +85,8 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 
 		parent_children = children.setdefault(node.parent_index, dict())
 
-		# If a node has multiple children we cannot connect its tail end to the children
+		# If a node has multiple children we cannot connect its tail end
+		# to the children.
 
 		#if node.sibling_index == -1 and not len(parent_children):
 		#	scene_node.use_connect = True
@@ -93,16 +94,23 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 		pos = absolute_transforms[i]['translation']
 		rot = absolute_transforms[i]['rotation']
 
-		scene_node.head = (pos[0] * scale, pos[1] * scale, pos[2] * scale)
-		# Make the bone a square dimension pointing in the direction we need it to
-		# point.
-		width = scene_node.bbone_x
-		thingy = Vector((width, 0.0, 0.0))
-		thingy.rotate(rot)
-		scene_node.tail = scene_node.head + thingy
+		# Bones when created start at 0 0 0 for their tail and head.
+		# We extend the tail so it sticks out a bit and signifies the direction.
 
-		# We need a roll, but this one is wrong. As long as we can't figure out a proper roll we're doomed.
-		scene_node.roll = Quaternion((-node.rot_w, node.rot_i, node.rot_j, node.rot_k)).to_euler('XYZ').z
+		scene_node.tail = (scene_node.bbone_x, 0.0, 0.0)
+
+		# We then rotate the bone by the absolute rotation that it should have.
+
+		scene_node.transform(rot.to_matrix(), scale=False)
+
+		# Then we add the absolute location to both the head and the tail.
+
+		base_pos = scene_node.head
+		scene_node.head = (base_pos.x + pos[0] * scale, base_pos.y + pos[1] * scale, base_pos.z + pos[2] * scale)
+		base_tail = scene_node.tail
+		scene_node.tail = (base_tail.x + pos[0] * scale, base_tail.y + pos[1] * scale, base_tail.z + pos[2] * scale)
+
+		# Store the info we gathered this cycle.
 
 		parent_children[i] = scene_node
 		children[node.parent_index] = parent_children

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -6,11 +6,12 @@ from reclaimer.hek.defs.mod2 import mod2_def
 from reclaimer.model.jms import read_jms
 from reclaimer.model.model_decompilation import extract_model
 
-from ..constants import ( JMS_VERSION_HALO_1, NODE_NAME_PREFIX, MARKER_NAME_PREFIX )
+from ..constants import (JMS_VERSION_HALO_1, NODE_NAME_PREFIX,
+	MARKER_NAME_PREFIX)
 from ..scene.shapes import create_sphere
-from ..scene.util import set_uniform_scale, reduce_vertices
-from ..scene.jms_util import ( set_rotation_from_jms,
-	set_translation_from_jms )
+from ..scene.util import (set_uniform_scale, reduce_vertices)
+from ..scene.jms_util import (set_rotation_from_jms,
+	set_translation_from_jms, get_absolute_node_transforms_from_jms)
 
 def read_halo1model(filepath):
 	'''Takes a halo1 model file and turns it into a jms object.'''
@@ -46,16 +47,15 @@ def read_halo1model(filepath):
 
 		return jms
 
-#from Blender.Mathutils import Quaternion, Vector
-
 def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 	'''
 	Import all the nodes from a jms into the scene and returns a dict of them.
 	'''
-	scene = bpy.context.collection
 	view_layer = bpy.context.view_layer
 
 	scene_nodes = dict()
+
+	absolute_transforms = get_absolute_node_transforms_from_jms(jms.nodes)
 
 	# Dictionary containing all child indices for each parent.
 	children = dict()
@@ -85,10 +85,14 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 
 		# If a node has multiple children we cannot connect it's tail end to the children
 
-		if node.sibling_index == -1 and not len(parent_children):
-			scene_node.use_connect = True
+		#if node.sibling_index == -1 and not len(parent_children):
+		#	scene_node.use_connect = True
 
-		scene_node.head = (node.pos_x * scale, node.pos_y * scale, node.pos_z * scale)
+		pos = absolute_transforms[i]['translation']
+		rot = absolute_transforms[i]['rotation']
+
+		scene_node.head = (pos[0] * scale, pos[1] * scale, pos[2] * scale)
+		scene_node.tail = (pos[0] * scale + 0.25, pos[1] * scale, pos[2] * scale)
 		#set_rotation_from_jms(scene_node, node)
 
 		#set_translation_from_jms(scene_node, node, scale)

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -68,8 +68,8 @@ def import_halo1_nodes_from_jms(jms, *,
 	max_attachment_distance is the max distance a bone may deviate from
 	the line that signifies the direction of the parent.
 
-	attach_bones is a tuple of prefixes that this function should attempt to
-	connect.
+	attach_bones is a tuple of name prefixes that this function should attempt
+	to connect.
 
 	Returns the armature object and a dict of index - bone pairs.
 	'''
@@ -232,9 +232,10 @@ def import_halo1_markers_from_jms(jms, *, armature=None, scale=1.0, node_size=0.
 			# Then we subtract the length of the parent bone from the y axis,
 			# the y axis being the axis that is offset.
 
-			# Halo bone behavior expects markers their 0 0 0 to be at the bone
-			# base. But when attaching in Blender its 0 0 0 is instead at the
-			# bone's tail end.
+			# In Halo, marker positions are relative to the start of their
+			# parent bone. In blender they are relative to the end of the bone.
+			# So, we subtract the length of the bone from the y axis to
+	        # make the final positions match up.
 			scene_marker.location.y -= parent.length
 
 	#TODO: Should this return something?

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -67,6 +67,8 @@ def import_halo1_nodes_from_jms(jms, *,
 
 	attach_bones is a tuple of prefixes that this function should attempt to
 	connect.
+
+	Returns the armature object and a dict of index - bone pairs.
 	'''
 	view_layer = bpy.context.view_layer
 
@@ -163,9 +165,9 @@ def import_halo1_nodes_from_jms(jms, *,
 
 	bpy.ops.object.mode_set(mode='OBJECT')
 
-	return scene_nodes
+	return armature_obj, scene_nodes
 
-def import_halo1_markers_from_jms(jms, *, scale=1.0, node_size=0.01,
+def import_halo1_markers_from_jms(jms, *, armature=None, scale=1.0, node_size=0.01,
 		scene_nodes=dict(), import_radius=False,
 		permutation_filter=(), region_filter=()
 		):
@@ -208,7 +210,11 @@ def import_halo1_markers_from_jms(jms, *, scale=1.0, node_size=0.01,
 			set_uniform_scale(scene_marker, marker.radius)
 
 		# Assign parent if index is valid.
-		scene_marker.parent = scene_nodes.get(marker.parent, None)
+		parent = scene_nodes.get(marker.parent, None)
+		if armature and parent:
+			scene_marker.parent = armature
+			scene_marker.parent_type = 'BONE'
+			scene_marker.parent_bone = parent.name
 
 		set_rotation_from_jms(scene_marker, marker)
 

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -60,7 +60,7 @@ def import_halo1_nodes_from_jms(jms, *,
 	Import all the nodes from a jms into the scene as an armature and returns
 	a dict of them.
 
-	node_size are is currently unused and may be depricated.
+	node_size is currently unused and may be depricated.
 
 	max_attachment_distance is the max distance a bone may deviate from
 	the line that signifies the direction of the parent.

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -1,5 +1,8 @@
 import bpy
 import itertools
+import math
+
+from mathutils import Euler
 
 from reclaimer.hek.defs.mode import mode_def
 from reclaimer.hek.defs.mod2 import mod2_def
@@ -209,6 +212,10 @@ def import_halo1_markers_from_jms(jms, *, armature=None, scale=1.0, node_size=0.
 		if import_radius:
 			set_uniform_scale(scene_marker, marker.radius)
 
+		set_rotation_from_jms(scene_marker, marker)
+
+		set_translation_from_jms(scene_marker, marker, scale)
+
 		# Assign parent if index is valid.
 		parent = scene_nodes.get(marker.parent, None)
 		if armature and parent:
@@ -216,9 +223,14 @@ def import_halo1_markers_from_jms(jms, *, armature=None, scale=1.0, node_size=0.
 			scene_marker.parent_type = 'BONE'
 			scene_marker.parent_bone = parent.name
 
-		set_rotation_from_jms(scene_marker, marker)
+			# Ajust location for difference in forward axis between Halo
+			# and Blender bones.
+			scene_marker.location.rotate(Euler((0.0, 0.0, math.radians(90.0))))
+			# Adjust location for being parented to the tail end of the bone
+			# rather than the head end.
+			scene_marker.location.y -= parent.length
 
-		set_translation_from_jms(scene_marker, marker, scale)
+
 
 	#TODO: Should this return something?
 

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -138,13 +138,16 @@ def import_halo1_nodes_from_jms(jms, *,
 		print('Checking if any bones with the prefixes %s can be connected.\n' %
 				(attach_bones,))
 
+	# Add the node prefix to in-tag prefixes that we should attempt to connect.
+	attach_bones = tuple(map(lambda p : NODE_NAME_PREFIX + p, attach_bones))
+
 	# Attach all the bones that we should attach if we can safely do so.
 	for bone in armature.edit_bones:
 		children = bone.children
 
 		if (len(children) == 1 # Can't connect to multiple children, so don't.
-		and bone.name[len(NODE_NAME_PREFIX): ].startswith(attach_bones)
-		and children[0].name[len(NODE_NAME_PREFIX): ].startswith(attach_bones)):
+		and bone.name.startswith(attach_bones)
+		and children[0].name.startswith(attach_bones)):
 			child = children[0]
 
 			distance = point_distance_to_line(
@@ -233,8 +236,6 @@ def import_halo1_markers_from_jms(jms, *, armature=None, scale=1.0, node_size=0.
 			# base. But when attaching in Blender its 0 0 0 is instead at the
 			# bone's tail end.
 			scene_marker.location.y -= parent.length
-
-
 
 	#TODO: Should this return something?
 

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -101,6 +101,7 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 		thingy.rotate(rot)
 		scene_node.tail = scene_node.head + thingy
 
+		# We need a roll, but this one is wrong. As long as we can't figure out a proper roll we're doomed.
 		scene_node.roll = Quaternion((-node.rot_w, node.rot_i, node.rot_j, node.rot_k)).to_euler('XYZ').z
 
 		parent_children[i] = scene_node

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -55,7 +55,7 @@ def import_halo1_nodes_from_jms(jms, *,
 		scale=1.0,
 		node_size=0.02,
 		max_attachment_distance=0.00001,
-		attach_nodes={'bip01': True, 'frame': False}):
+		attach_bones=('bip01',)):
 	'''
 	Import all the nodes from a jms into the scene and returns a dict of them.
 	'''
@@ -121,13 +121,6 @@ def import_halo1_nodes_from_jms(jms, *,
 		direction = Vector((1000.0, 0.0, 0.0))
 		direction.rotate(rot)
 		directions[scene_node.name] = direction
-
-	# Collect all the bone prefixes that need to be attached in a tuple.
-	attach_bones = ()
-	if max_attachment_distance >= 0:
-		for k in attach_nodes:
-			if attach_nodes[k]:
-				attach_bones += (k,)
 
 	# Attach all the bones that we should attach if we can safely do so.
 	for bone in armature.edit_bones:

--- a/halo1/model.py
+++ b/halo1/model.py
@@ -47,9 +47,8 @@ def read_halo1model(filepath):
 
 		return jms
 
-from mathutils import Vector, Quaternion
 
-def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
+def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02, extend_nodes={'bip01': True, 'frame': False}):
 	'''
 	Import all the nodes from a jms into the scene and returns a dict of them.
 	'''
@@ -58,9 +57,6 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 	scene_nodes = dict()
 
 	absolute_transforms = get_absolute_node_transforms_from_jms(jms.nodes)
-
-	# Dictionary containing all child indices for each parent.
-	children = dict()
 
 	armature = bpy.data.armatures.new('imported')
 	armature_obj = bpy.data.objects.new('imported', armature)
@@ -75,7 +71,6 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 
 	edit_bones = armature.edit_bones
 	bpy.ops.object.mode_set(mode='EDIT')
-	#pose_bones = armature.pose_position.bones
 
 	for i, node in enumerate(jms.nodes):
 		scene_node = edit_bones.new(name=NODE_NAME_PREFIX+node.name)
@@ -83,13 +78,8 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 		# Assign parent if index is valid.
 		scene_node.parent = scene_nodes.get(node.parent_index, None)
 
-		parent_children = children.setdefault(node.parent_index, dict())
-
 		# If a node has multiple children we cannot connect its tail end
 		# to the children.
-
-		#if node.sibling_index == -1 and not len(parent_children):
-		#	scene_node.use_connect = True
 
 		pos = absolute_transforms[i]['translation']
 		rot = absolute_transforms[i]['rotation']
@@ -111,9 +101,6 @@ def import_halo1_nodes_from_jms(jms, *, scale=1.0, node_size=0.02):
 		scene_node.tail = (base_tail.x + pos[0] * scale, base_tail.y + pos[1] * scale, base_tail.z + pos[2] * scale)
 
 		# Store the info we gathered this cycle.
-
-		parent_children[i] = scene_node
-		children[node.parent_index] = parent_children
 		scene_nodes[i] = scene_node
 
 	bpy.ops.object.mode_set(mode='OBJECT')

--- a/menu/import_export/halo1_model.py
+++ b/menu/import_export/halo1_model.py
@@ -100,10 +100,10 @@ class MT_krieg_ImportHalo1Model(bpy.types.Operator, ImportHelper):
 
 		# Import nodes into the scene.
 		nodes = import_halo1_nodes_from_jms(jms, scale=scale, node_size=self.node_size)
-		import_halo1_markers_from_jms(jms, scale=scale,
-			node_size=self.marker_size, scene_nodes=nodes)
+		#import_halo1_markers_from_jms(jms, scale=scale,
+		#	node_size=self.marker_size, scene_nodes=nodes)
 
-		import_halo1_all_regions_from_jms(jms, name=name, scale=scale)
+		#import_halo1_all_regions_from_jms(jms, name=name, scale=scale)
 
 		return {'FINISHED'}
 

--- a/menu/import_export/halo1_model.py
+++ b/menu/import_export/halo1_model.py
@@ -99,9 +99,10 @@ class MT_krieg_ImportHalo1Model(bpy.types.Operator, ImportHelper):
 		name = os.path.basename(os.path.splitext(self.filepath)[0])
 
 		# Import nodes into the scene.
-		nodes = import_halo1_nodes_from_jms(jms, scale=scale, node_size=self.node_size)
-		#import_halo1_markers_from_jms(jms, scale=scale,
-		#	node_size=self.marker_size, scene_nodes=nodes)
+		armature, nodes = import_halo1_nodes_from_jms(jms, scale=scale, node_size=self.node_size)
+		# Import markers.
+		import_halo1_markers_from_jms(jms, scale=scale,
+			node_size=self.marker_size, armature=armature, scene_nodes=nodes)
 
 		import_halo1_all_regions_from_jms(jms, name=name, scale=scale)
 

--- a/menu/import_export/halo1_model.py
+++ b/menu/import_export/halo1_model.py
@@ -103,7 +103,7 @@ class MT_krieg_ImportHalo1Model(bpy.types.Operator, ImportHelper):
 		#import_halo1_markers_from_jms(jms, scale=scale,
 		#	node_size=self.marker_size, scene_nodes=nodes)
 
-		#import_halo1_all_regions_from_jms(jms, name=name, scale=scale)
+		import_halo1_all_regions_from_jms(jms, name=name, scale=scale)
 
 		return {'FINISHED'}
 

--- a/scene/jms_util.py
+++ b/scene/jms_util.py
@@ -25,6 +25,9 @@ def get_absolute_node_transforms_from_jms(node_list):
 	'''
 	Takes a JmsNodes list and returns the absolute transformations in a dict.
 	'''
+	# This could be a list. But we keep it a dict to keep the implementation
+	# style synced across different modules. It also allows us to leverage
+	# dictionary functions.
 	node_transforms = {}
 
 	for i, node in enumerate(node_list):

--- a/scene/jms_util.py
+++ b/scene/jms_util.py
@@ -1,7 +1,7 @@
 '''
 Functions for interfacing Jms stuff with the Blender scene.
 '''
-
+from mathutils import Quaternion, Vector
 from .util import set_rotation, set_translation
 
 def set_rotation_from_jms(scene_object, jms_piece):
@@ -20,3 +20,32 @@ def set_translation_from_jms(scene_object, jms_piece, scale=1.0):
 		x=jms_piece.pos_x,
 		y=jms_piece.pos_y,
 		z=jms_piece.pos_z)
+
+def get_absolute_node_transforms_from_jms(node_list):
+	'''
+	Takes a JmsNodes list and returns the absolute transformations in a dict.
+	'''
+	node_transforms = {}
+
+	for i, node in enumerate(node_list):
+		translation = Vector((node.pos_x, node.pos_y, node.pos_z))
+		rotation = Quaternion((-node.rot_w, node.rot_i, node.rot_j, node.rot_k))
+
+		if node.parent_index >= 0:
+			parent = node_transforms[node.parent_index]
+
+			abs_rotation    = parent['rotation'] @ rotation
+			# Rotating this way has the result end up in the instance
+			# we're calling this method from.
+			translation.rotate(parent['rotation'])
+			abs_translation = parent['translation'] + translation
+		else:
+			abs_translation = translation
+			abs_rotation    = rotation
+
+		node_transforms[i] = {
+			'translation': abs_translation,
+			'rotation': abs_rotation,
+		}
+
+	return node_transforms

--- a/scene/util.py
+++ b/scene/util.py
@@ -3,6 +3,8 @@ Functions for interfacing Halo stuff with the Blender scene.
 '''
 import itertools
 
+from mathutils import Vector
+
 def set_rotation(scene_object, *, i=0.0, j=0.0, k=0.0, w=-1.0):
 	'''
 	Helper to apply a rotation from Halo to an object in the scene.
@@ -97,3 +99,16 @@ def reduce_vertices(verts, tris):
 
 	# Return as tuples because they are nice and fast.
 	return tuple(new_verts), tuple(new_tris)
+
+def trace_into_direction(direction, distance=10000.0):
+	'''
+	Creates a point at (default) 10000 units into the given direction.
+	Supports Euler, Quaternion, Matrix.
+	'''
+	# First we create the point at the distance we want it.
+	point = Vector((distance, 0.0, 0.0))
+	# Then we rotate it from the 0 0 0 point so it's in the direction given
+	# as a function input.
+	point.rotate(direction)
+
+	return point


### PR DESCRIPTION
This pull request adjusts the node import so that it imports as armatures. A lot more work goes into armatures than into objects. So it will be a bit dense.

~~Currently marker import is disabled. This is because it will need to be adjusted to work with this implementation. That will be the next pull request.~~
![Screenshot_20200217_112725](https://user-images.githubusercontent.com/24233409/74645598-86efa880-5178-11ea-9a6f-e7922ca8293f.png)

